### PR TITLE
Motion Ad Dynamic Colors Updates

### DIFF
--- a/src/classes/color-variable.js
+++ b/src/classes/color-variable.js
@@ -1,0 +1,24 @@
+export default class ColorVariable {
+
+  constructor(document, colorName, hexCode) {
+    this.document = document;
+    this.colorName = colorName;
+    this.hexCode = hexCode;
+    this.variables = document.swatches;
+  }
+
+  update() {
+    var colorVariable = this.getVariable();
+    colorVariable.sketchObject.updateWithColor(
+      MSColor.colorWithHex_alpha(this.hexCode, 1)
+    );
+  }
+
+  getVariable() {
+    var swatchName = this.colorName + " color"
+    return this.variables.filter(function (color) {
+      return color.name === swatchName
+    })[0];
+  }
+
+}

--- a/src/classes/color.js
+++ b/src/classes/color.js
@@ -140,6 +140,14 @@ export default class Color {
     for (var j = 0; j < overlayBarLayers.length; j++) {
       if (vertical == 'Wealth Management')
         { overlayBarLayers[j].style.opacity = 0.5 }
+      else if (vertical == 'Motion Real Estate') {
+        console.log(overlayBarLayers[j]);
+        var barGradient = overlayBarLayers[j].style.fills[0].gradient;
+        // Alpha 0%
+        barGradient.stops[0].color = (this.localColor().slice(0, -2) + '00');
+        // Alpha 100%
+        barGradient.stops[1].color = (this.localColor().slice(0, -2) + 'FF');
+      }
       else {
         var barGradient = overlayBarLayers[j].style.fills[0].gradient
         // Alpha 57%

--- a/src/classes/color.js
+++ b/src/classes/color.js
@@ -1,11 +1,15 @@
+import ColorVariable from "./color-variable";
+
 export default class Color {
   constructor(document, fieldName) {
     this.document = document;
+    this.fieldName = fieldName;
     this.input = fieldName + "-color-input";
     this.text = fieldName + "-color-text";
     this.display = fieldName + "-color-display";
-    this.font = fieldName + "-font-color";
     this.group = fieldName + " color";
+    // this.font = fieldName + "-font-color";
+
   }
 
   update(vertical) {
@@ -13,10 +17,10 @@ export default class Color {
       var colorGroup = this.document.getLayersNamed(this.group)[0];
       colorGroup.hidden = true;
     } else {
-      this.setDisplay();
+      // this.setDisplay();
       this.setAdColors(vertical);
-      this.setText();
-      this.setFontColor();
+      // this.setText();
+      // this.setFontColor();
     }
   }
 
@@ -43,20 +47,31 @@ export default class Color {
     return this;
   }
 
+  setColorVariable() {
+    var colorName = this.fieldName;
+    var hexCode = this.getInputLayer().text;
+    new ColorVariable(this.document, colorName, hexCode).update();
+  }
+
   setAdColors(vertical) {
-    this.setSharedStyle();
-    var sharedColorLayers = this.getSharedStyle().getAllInstancesLayers();
-    for (var i = 0; i < sharedColorLayers.length; i++) {
-      sharedColorLayers[i].style.syncWithSharedStyle(this.getSharedStyle());
-      var textLayers = this.findLocalText(sharedColorLayers[i]);
-      this.setTextColor(textLayers);
-      var buttonBorderLayers = this.findLocalButtonBorders(sharedColorLayers[i]);
-      if (buttonBorderLayers.length > 0) {
-        this.setButtonBorderColor(buttonBorderLayers);
+    if (vertical === 'Motion Real Estate') {
+      console.log(this.fieldName);
+      this.setColorVariable();
+    } else {
+      this.setSharedStyle();
+      var sharedColorLayers = this.getSharedStyle().getAllInstancesLayers();
+      for (var i = 0; i < sharedColorLayers.length; i++) {
+        sharedColorLayers[i].style.syncWithSharedStyle(this.getSharedStyle());
+        // var textLayers = this.findLocalText(sharedColorLayers[i]);
+        // this.setTextColor(textLayers);
+        var buttonBorderLayers = this.findLocalButtonBorders(sharedColorLayers[i]);
+        if (buttonBorderLayers.length > 0) {
+          this.setButtonBorderColor(buttonBorderLayers);
+        }
       }
-    }
-    if (this.input === 'primary-color-input') {
-      this.setOverlayBarColor(vertical);
+      if (this.input === 'primary-color-input') {
+        this.setOverlayBarColor(vertical);
+      }
     }
   }
 
@@ -80,11 +95,11 @@ export default class Color {
     })
   }
 
-  setTextColor(textLayers) {
-    for (var j = 0; j < textLayers.length; j++) {
-      textLayers[j].style.textColor = this.outputColor(this.localColor())
-    }
-  }
+  // setTextColor(textLayers) {
+  //   for (var j = 0; j < textLayers.length; j++) {
+  //     textLayers[j].style.textColor = this.outputColor(this.localColor())
+  //   }
+  // }
 
   setText() {
     this.getTextLayer().text = this.localColor().slice(0, -2);

--- a/src/classes/color.js
+++ b/src/classes/color.js
@@ -3,13 +3,10 @@ import ColorVariable from "./color-variable";
 export default class Color {
   constructor(document, fieldName) {
     this.document = document;
-    this.fieldName = fieldName;
     this.input = fieldName + "-color-input";
     this.text = fieldName + "-color-text";
     this.display = fieldName + "-color-display";
     this.group = fieldName + " color";
-    // this.font = fieldName + "-font-color";
-
   }
 
   update(vertical) {
@@ -17,10 +14,12 @@ export default class Color {
       var colorGroup = this.document.getLayersNamed(this.group)[0];
       colorGroup.hidden = true;
     } else {
-      // this.setDisplay();
+      this.setDisplay();
       this.setAdColors(vertical);
-      // this.setText();
-      // this.setFontColor();
+      this.setText();
+      if (vertical === 'Motion Real Estate' && this.input === 'secondary-color-input') {
+        this.setFontColor();
+      }
     }
   }
 
@@ -54,24 +53,19 @@ export default class Color {
   }
 
   setAdColors(vertical) {
-    if (vertical === 'Motion Real Estate') {
-      console.log(this.fieldName);
-      this.setColorVariable();
-    } else {
-      this.setSharedStyle();
-      var sharedColorLayers = this.getSharedStyle().getAllInstancesLayers();
-      for (var i = 0; i < sharedColorLayers.length; i++) {
-        sharedColorLayers[i].style.syncWithSharedStyle(this.getSharedStyle());
-        // var textLayers = this.findLocalText(sharedColorLayers[i]);
-        // this.setTextColor(textLayers);
-        var buttonBorderLayers = this.findLocalButtonBorders(sharedColorLayers[i]);
-        if (buttonBorderLayers.length > 0) {
-          this.setButtonBorderColor(buttonBorderLayers);
-        }
+    this.setSharedStyle();
+    var sharedColorLayers = this.getSharedStyle().getAllInstancesLayers();
+    for (var i = 0; i < sharedColorLayers.length; i++) {
+      sharedColorLayers[i].style.syncWithSharedStyle(this.getSharedStyle());
+      var textLayers = this.findLocalText(sharedColorLayers[i]);
+      this.setTextColor(textLayers);
+      var buttonBorderLayers = this.findLocalButtonBorders(sharedColorLayers[i]);
+      if (buttonBorderLayers.length > 0) {
+        this.setButtonBorderColor(buttonBorderLayers);
       }
-      if (this.input === 'primary-color-input') {
-        this.setOverlayBarColor(vertical);
-      }
+    }
+    if (this.input === 'primary-color-input') {
+      this.setOverlayBarColor(vertical);
     }
   }
 
@@ -95,21 +89,26 @@ export default class Color {
     })
   }
 
-  // setTextColor(textLayers) {
-  //   for (var j = 0; j < textLayers.length; j++) {
-  //     textLayers[j].style.textColor = this.outputColor(this.localColor())
-  //   }
-  // }
+  setTextColor(textLayers) {
+    for (var j = 0; j < textLayers.length; j++) {
+      textLayers[j].style.textColor = this.outputColor(this.localColor())
+    }
+  }
 
   setText() {
     this.getTextLayer().text = this.localColor().slice(0, -2);
   }
 
   setFontColor() {
-    var text = this.document.getLayersNamed(this.font);
-    for (var i = 0; i < text.length; i++) {
-      text[i].style.textColor = this.localColor()
-    }
+    var changingHeadline = this.document.getLayersNamed('Headline').filter(function (local) {
+      return local.getParentArtboard().name === 'listings-3-web-slide2'
+    })[0];
+    changingHeadline.style.textColor = this.localColor();
+
+    var changingPhone = this.document.getLayersNamed('Phone Number').filter(function (local) {
+      return local.getParentArtboard().name === 'listings-3-web-slide3'
+    })[0];
+    changingPhone.style.textColor = this.localColor();
   }
 
   findLocalButtonBorders(colorLayer) {

--- a/src/default-ads.js
+++ b/src/default-ads.js
@@ -7,7 +7,6 @@ import TextField from './classes/text-field';
 import PhoneField from './classes/phone-field';
 import ImageSizer from './classes/image-sizer';
 import LogoLocator from './classes/logo-locator';
-
 // import PhotoLocator from './classes/photo-locator';
 
 var document = require('sketch/dom').getSelectedDocument();
@@ -25,14 +24,14 @@ export default function() {
 export function updateColors(vertical) {
   new Color(document, 'primary').update(vertical);
   new Color(document, 'secondary').update(vertical);
-  this.handleTertiary(vertical);
-  new Color(document, 'additional-1').update(vertical);
-  new Color(document, 'additional-2').update(vertical);
+  this.handleTertiary();
+  new Color(document, 'additional-1').update();
+  new Color(document, 'additional-2').update();
 }
 
-export function handleTertiary(vertical) {
+export function handleTertiary() {
   var tertiary = new Color(document, 'tertiary');
-  tertiary.update(vertical);
+  tertiary.update();
   var hideTertiary = tertiary.isEmpty();
   new ColorSwatch(document, hideTertiary).update();
 }

--- a/src/default-ads.js
+++ b/src/default-ads.js
@@ -7,7 +7,8 @@ import TextField from './classes/text-field';
 import PhoneField from './classes/phone-field';
 import ImageSizer from './classes/image-sizer';
 import LogoLocator from './classes/logo-locator';
-import PhotoLocator from './classes/photo-locator';
+
+// import PhotoLocator from './classes/photo-locator';
 
 var document = require('sketch/dom').getSelectedDocument();
 
@@ -23,15 +24,15 @@ export default function() {
 
 export function updateColors(vertical) {
   new Color(document, 'primary').update(vertical);
-  new Color(document, 'secondary').update();
-  this.handleTertiary();
-  new Color(document, 'additional-1').update();
-  new Color(document, 'additional-2').update();
+  new Color(document, 'secondary').update(vertical);
+  this.handleTertiary(vertical);
+  new Color(document, 'additional-1').update(vertical);
+  new Color(document, 'additional-2').update(vertical);
 }
 
-export function handleTertiary() {
+export function handleTertiary(vertical) {
   var tertiary = new Color(document, 'tertiary');
-  tertiary.update();
+  tertiary.update(vertical);
   var hideTertiary = tertiary.isEmpty();
   new ColorSwatch(document, hideTertiary).update();
 }


### PR DESCRIPTION
This update allows for more dynamic color on Motion Ad Template 3:
- Text color changes to the secondary color on Slide 2 Headline and Slide 3 Phone Number.
- Gradient overlay on Slide 1, Slide 2, and Social Media Style changes to the primary color.

Technically, the `ColorVariable` class and associated references aren't necessary here. It's possible to use [Color Variables/Swatches](https://developer.sketch.com/reference/api/#swatch) to handle colors, but this would mean updating the templates for other verticals and that would mean that existing layout files would not work with the updated plugin. I left the code here in case we go in that direction in the future.